### PR TITLE
Community changes 2

### DIFF
--- a/userscript.js
+++ b/userscript.js
@@ -164,7 +164,8 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
             if (ended)
                 return;
             log.success(`Ended at ${new Date().toLocaleString()}! Total time: ${msToHMS(Date.now() - start.getTime())}`);
-            printDelayStats();
+            // unnecessary
+            // printDelayStats();
             log.verb(`Rate Limited: ${throttledCount} times. Total time throttled: ${msToHMS(throttledTotalTime)}.`);
             const computedSkip = grandTotal - delCount - failCount;
             // archivedSkipCount retained for diagnostics, but not shown to user

--- a/userscript.js
+++ b/userscript.js
@@ -641,7 +641,23 @@ function initUI() {
         }
     };
     stopBtn.onclick = e => stop = stopBtn.disabled = !(startBtn.disabled = false);
-    $('button#clear').onclick = e => { logArea.innerHTML = ''; };
+    $('button#clear').onclick = e => {
+        logArea.innerHTML = '';
+
+        const progress = $('#progress');
+        const progress2 = btn.querySelector('progress');
+        const percent = $('.percent');
+
+        progress.style.display = 'none';
+        progress2.style.display = 'none';
+        progress.removeAttribute('max');
+        progress2.removeAttribute('max');
+        progress.value = 0;
+        progress2.value = 0;
+        progress.style.accentColor = '';
+        progress2.style.accentColor = '';
+        percent.textContent = '';
+    };
     $('button#getToken').onclick = e => {
         //window.dispatchEvent(new Event('beforeunload'));
         //const ls = document.body.appendChild(document.createElement('iframe')).contentWindow.localStorage;

--- a/userscript.js
+++ b/userscript.js
@@ -183,7 +183,6 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                     });
                     lastPing = (Date.now() - s);
                     avgPing = (avgPing * 0.9) + (lastPing * 0.1);
-                    delCount++;
                 } catch (err) {
                     log.error('Delete request throwed an error:', err);
                     log.verb('Related object:', redact(JSON.stringify(message)));
@@ -230,6 +229,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                     // success
                     failInRow = 0;
                     successInRow++;
+                    delCount++;
                     if (randomizeDelay) {
                         deleteDefault = Math.floor(Math.random() * (2000 - 1000 + 1) + 1000);
                         deleteDelay = deleteDefault;

--- a/userscript.js
+++ b/userscript.js
@@ -190,8 +190,9 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
 
             if (++iterations < 1) {
                 log.verb(`Waiting for your confirmation...`);
+                const previewMessages = [...messagesToDelete].reverse();
                 if (!await ask(`Do you want to delete ~${total} messages?\nEstimated time: ${etr}\n\n---- Preview ----\n` +
-                    messagesToDelete.map(m => `${m.author.username}#${m.author.discriminator}: ${m.attachments.length ? '[ATTACHMENTS]' : m.content}`).join('\n')))
+                    previewMessages.map(m => `${m.author.username}#${m.author.discriminator}: ${m.attachments.length ? '[ATTACHMENTS]' : m.content}`).join('\n')))
                     return end(log.error('Aborted by you!'));
                 log.verb(`OK`);
             }

--- a/userscript.js
+++ b/userscript.js
@@ -26,11 +26,18 @@
  */
 async function deleteMessages(authToken, authorId, guildId, channelId, minId, maxId, content, hasLink, hasFile, includeNsfw, includePinned, extLogger, stopHndl, onProgress) {
     const start = new Date();
+    // keep track of channels (threads) that have been archived so we stop
+    // attempting further deletes against them; the search API may still
+    // return hits for messages in an archived thread, but every delete will
+    // fail and we risk infinite retry loops or excessive rate-limiting.
+    const ArchivedThreads = new Set();
     let deleteDefault = Math.floor(Math.random() * (2000 - 1000 + 1) + 1000);
     let deleteDelay = deleteDefault;
     let randomizeDelay = true;
     let searchDelay = Math.floor(Math.random() * (2000 - 1000 + 1) + 1000);
     let delCount = 0;
+    let skipCount = 0;            // messages we could not delete (system/archive)
+    let archivedSkipCount = 0;    // subset of skipCount belonging to archived threads
     let failCount = 0;
     let avgPing;
     let lastPing;
@@ -130,10 +137,28 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
         const total = data.total_results;
         if (!grandTotal) grandTotal = total;
         const discoveredMessages = data.messages.map(convo => convo.find(message => message.hit === true));
-        const messagesToDelete = discoveredMessages.filter(msg => {
+        // Filter out system messages and optionally pinned ones
+        let messagesToDelete = discoveredMessages.filter(msg => {
             return msg.type === 0 || msg.type === 6 || (msg.pinned && includePinned);
         });
+        // remove any messages belonging to threads we've already marked archived
+        messagesToDelete = messagesToDelete.filter(msg => {
+            if (ArchivedThreads.has(msg.channel_id)) {
+                log.verb(`Skipping message in archived thread ${msg.channel_id}`);
+                return false;
+            }
+            return true;
+        });
         const skippedMessages = discoveredMessages.filter(msg => !messagesToDelete.find(m => m.id === msg.id));
+        // update global counters
+        skipCount += skippedMessages.length;
+        const archivedCount = skippedMessages.filter(msg => ArchivedThreads.has(msg.channel_id)).length;
+        const systemCount = skippedMessages.length - archivedCount;
+        archivedSkipCount += archivedCount;
+        // signal progress UI that undeletable messages were found
+        if (skippedMessages.length > 0) {
+            try { if (onProgress) onProgress(delCount, grandTotal || 1, true); } catch (e) { }
+        }
 
         const end = () => {
             if (ended)
@@ -141,12 +166,22 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
             log.success(`Ended at ${new Date().toLocaleString()}! Total time: ${msToHMS(Date.now() - start.getTime())}`);
             printDelayStats();
             log.verb(`Rate Limited: ${throttledCount} times. Total time throttled: ${msToHMS(throttledTotalTime)}.`);
-            log.debug(`Deleted ${delCount} messages, ${failCount} failed.\n`);
+            const computedSkip = grandTotal - delCount - failCount;
+            // archivedSkipCount retained for diagnostics, but not shown to user
+            log.debug(`Deleted ${delCount} messages, ${failCount} failed, ${computedSkip} skipped.\n`);
+            // update UI to show final deleted count vs deletable messages
+            // do not update UI here; the last onProgress from the loop already
+            // reflected the most recent state. calling onProgress at end caused
+            // spurious resets (blue/full) when the run ended incomplete.
             ended = true;
         }
 
-        const etr = msToHMS((searchDelay * Math.round(total / 25)) + ((deleteDelay + avgPing) * total));
-        log.info(`Total messages found: ${data.total_results}`, `(Messages in current page: ${data.messages.length}, To be deleted: ${messagesToDelete.length}, System: ${skippedMessages.length})`, `offset: ${offset}`);
+        const deletableMessages = grandTotal - archivedSkipCount;
+        const etr = msToHMS((searchDelay * Math.round(deletableMessages / 25)) + ((deleteDelay + avgPing) * deletableMessages));
+        // systemCount already computed above when updating counters
+        log.info(`Total messages found: ${data.total_results}`,
+            `(Hits: ${data.messages.length}, Delete: ${messagesToDelete.length}, Skipped: ${skippedMessages.length} (system ${systemCount}))`,
+            `offset: ${offset}`);
         printDelayStats();
         log.verb(`Estimated time remaining: ${etr}`)
 
@@ -163,15 +198,21 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
 
             for (let i = 0; i < messagesToDelete.length; i++) {
                 const message = messagesToDelete[i];
+                // if we've already marked this thread as archived, skip
+                if (ArchivedThreads.has(message.channel_id)) {
+                    log.verb(`Skipping message in archived thread ${message.channel_id}`);
+                    continue;
+                }
                 if (stopHndl && stopHndl() === false) return end(log.error('Stopped by you!'));
 
                 // Too big to read, too much information to be useful to end user
                 // if you care about individual IDs being deleted or your username, there ya go:
                 //log.debug(`${((delCount + 1) / grandTotal * 100).toFixed(2)}% (${delCount + 1}/${grandTotal})` + `Delete ID:${redact(message.id)} <b>${redact(message.author.username + '#' + message.author.discriminator)} <small>(${redact(new Date(message.timestamp).toLocaleString())})</small>:</b> <i>${redact(message.content).replace(/\n/g, '↵')}</i>`, message.attachments.length ? redact(JSON.stringify(message.attachments)) : '');
-                log.debug(`${((delCount + 1) / grandTotal * 100).toFixed(2)}% (${delCount + 1}/${grandTotal})` + ` | <b>DEL</b> <small>(${redact(new Date(message.timestamp).toLocaleDateString() + " - " + new Date(message.timestamp).toLocaleTimeString())})</small>: ${redact(message.content).replace(/\n/g, '↵')}`, message.attachments.length ? redact(JSON.stringify(message.attachments)) : '');
+                const processed = delCount + skipCount;
+                log.debug(`${((processed + 1) / grandTotal * 100).toFixed(2)}% (${processed + 1}/${grandTotal})` + ` | <b>DEL</b> <small>(${redact(new Date(message.timestamp).toLocaleDateString() + " - " + new Date(message.timestamp).toLocaleTimeString())})</small>: ${redact(message.content).replace(/\n/g, '↵')}`, message.attachments.length ? redact(JSON.stringify(message.attachments)) : '');
 
 
-                if (onProgress) onProgress(delCount + 1, grandTotal);
+                // progress reflects actual deleted messages (and adjusts when archived threads are detected)
 
                 let resp;
                 try {
@@ -191,13 +232,28 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
 
                 if (!resp.ok) {
                     // failed
+                    let err;
+                    try { err = await resp.json(); } catch { err = null; }
+
                     failInRow++;
                     successInRow = 0;
                     randomizeDelay = false;
 
+                    // thread archived – API can return a few different codes or
+                    // messages depending on context.
+                    if ((resp.status === 400 && err?.code === 50083) ||
+                        (resp.status === 403 && err?.message && /archiv/i.test(err.message)) ||
+                        (resp.status === 404 && err?.message && /archiv/i.test(err.message))) {
+                        log.warn(`Archived thread detected (status ${resp.status}${err?.code ? ', code ' + err.code : ''}), marking channel ${message.channel_id} as archived`);
+                        ArchivedThreads.add(message.channel_id);
+                        // accounting/offset for this message is handled in the page-level
+                        // skippedMessages block to avoid double counting.
+                        continue;
+                    }
+
                     // deleting messages too fast
-                    if (resp.status === 429) {
-                        const w = (await resp.json()).retry_after;
+                    else if (resp.status === 429) {
+                        const w = err?.retry_after;
                         log.warn(`Failed to delete - Discord said go away for ${w}ms!`);
 
                         throttledCount++;
@@ -219,8 +275,9 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
 
                         await wait(deleteDelay);
                         i--; // retry
-                    } else {
-                        log.error(`Error deleting message, API responded with status ${resp.status}!`, await resp.json());
+                    }
+                    else {
+                        log.error(`Error deleting message, API responded with status ${resp.status}!`, err);
                         log.verb('Related object:', redact(JSON.stringify(message)));
                         failCount++;
                     }
@@ -230,6 +287,8 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                     failInRow = 0;
                     successInRow++;
                     delCount++;
+                    // update progress after a successful delete
+                    try { if (onProgress) onProgress(delCount, grandTotal || 1); } catch (e) { }
                     if (randomizeDelay) {
                         deleteDefault = Math.floor(Math.random() * (2000 - 1000 + 1) + 1000);
                         deleteDelay = deleteDefault;
@@ -248,13 +307,22 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                 }
 
 
-                await wait(deleteDelay);
+                // avoid an unnecessary delay after processing the last message
+                if (i < messagesToDelete.length - 1) {
+                    await wait(deleteDelay);
+                }
             }
 
             if (skippedMessages.length > 0) {
                 /*grandTotal -= skippedMessages.length;*/
                 offset += skippedMessages.length;
                 log.verb(`Found ${skippedMessages.length} system messages! Increasing offset to ${offset}.`);
+            }
+
+            // All results are already accounted for (deleted/failed/skipped),
+            // no need to issue another search request.
+            if ((delCount + failCount + skipCount) >= grandTotal) {
+                return end();
             }
 
             log.verb(`Searching next messages in ${searchDelay}ms...`, (offset ? `(offset: ${offset})` : ''));
@@ -272,9 +340,27 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
 
             return await recurse();
         } else {
+            // nothing on this page could be deleted (either system or archived)
+            if (skippedMessages.length > 0) {
+                const archivedCount = skippedMessages.filter(msg => ArchivedThreads.has(msg.channel_id)).length;
+                const systemCount = skippedMessages.length - archivedCount;
+                log.verb(`No deletable messages on this page (${systemCount} system, ${archivedCount} archived). Advancing offset by ${skippedMessages.length}.`);
+                offset += skippedMessages.length;
+                if ((delCount + failCount + skipCount) >= grandTotal) {
+                    return end();
+                }
+                if (offset >= total) {
+                    return end();
+                }
+                log.verb(`Searching next messages in ${searchDelay}ms...`, `(offset: ${offset})`);
+                await wait(searchDelay);
+                return await recurse();
+            }
             if (total - offset > 0) {
                 log.warn('API returned an empty page. Searching next page.');
                 offset += 25;
+                log.verb(`Searching next messages in ${searchDelay}ms...`, `(offset: ${offset})`);
+                await wait(searchDelay);
                 await recurse();
                 return end();
             } else {
@@ -287,7 +373,8 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
     log.success(`\nStarted at ${start.toLocaleString()}`);
     log.debug(`authorId="${redact(authorId)}" guildId="${redact(guildId)}" channelId="${redact(channelId)}" minId="${redact(minId)}" maxId="${redact(maxId)}" hasLink=${!!hasLink} hasFile=${!!hasFile}`);
     ended = false;
-    if (onProgress) onProgress(null, 1);
+    // initialize progress at 0 so percent shows and color is blue immediately
+    try { if (onProgress) onProgress(0, 1); } catch (e) { }
     return await recurse();
 }
 
@@ -330,6 +417,13 @@ function initUI() {
         #undiscord .header{padding:12px 16px;background-color:var(--background-tertiary);color:var(--text-muted)}
         #undiscord .form{padding:8px;background:var(--background-secondary);box-shadow:0 1px 0 rgba(0,0,0,.2),0 1.5px 0 rgba(0,0,0,.05),0 2px 0 rgba(0,0,0,.05)}
         #undiscord .logarea{overflow:auto;font-size:.75rem;font-family:Consolas,Liberation Mono,Menlo,Courier,monospace;flex-grow:1;padding:10px}
+        #undiscord progress.complete { accent-color: #43b581; }
+        #undiscord progress.incomplete { accent-color: #f04747; }
+        #undiscord progress.pending { accent-color: #5865f2; }
+        /* also style the small progress inside the toolbar button */
+        #undicord-btn progress.complete { accent-color: #43b581; }
+        #undicord-btn progress.incomplete { accent-color: #f04747; }
+        #undicord-btn progress.pending { accent-color: #5865f2; }
         .logarea { scrollbar-width: none;}
         `);
 
@@ -496,19 +590,51 @@ function initUI() {
 
         const stopHndl = () => !(stop === true);
 
-        const onProg = (value, max) => {
+        let hasUndeletable = false;
+        const onProg = (value, max, markUndeletable = false) => {
+            if (markUndeletable) hasUndeletable = true;
             if (value && max && value > max) max = value;
             progress.setAttribute('max', max);
             progress.value = value;
-            progress.style.display = max ? '' : 'none';
+            // always keep the progress visible so the final red/green state can be seen
+            progress.style.display = '';
             progress2.setAttribute('max', max);
             progress2.value = value;
-            progress2.style.display = max ? '' : 'none';
-            percent.innerHTML = value && max ? Math.round(value / max * 100) + '%' : '';
+            progress2.style.display = '';
+            // show percentage even when value is 0 (0 is falsy), but only when both numbers are provided
+            if (typeof value === 'number' && typeof max === 'number' && max > 0) {
+                percent.innerHTML = Math.round(value / max * 100) + '%';
+            }
+
+            // blue by default, red if any undeletable was seen, green only when fully complete with no undeletables
+            if (hasUndeletable) {
+                progress.style.accentColor = '#f04747';  // red
+                progress2.style.accentColor = '#f04747';
+            } else if (max && value >= max) {
+                // all deleted - show green
+                progress.style.accentColor = '#43b581';  // green
+                progress2.style.accentColor = '#43b581';
+            } else if (max) {
+                // pending/in-progress with no undeletables
+                progress.style.accentColor = '#5865f2';  // blue
+                progress2.style.accentColor = '#5865f2';
+            } else {
+                // reset to default
+                progress.style.accentColor = '';
+                progress2.style.accentColor = '';
+            }
         };
 
 
         stop = stopBtn.disabled = !(startBtn.disabled = true);
+        // pre-reset progress bar so it starts blue immediately
+        progress.setAttribute('max', 1);
+        progress.value = 0;
+        progress.style.accentColor = '#5865f2';
+        progress2.setAttribute('max', 1);
+        progress2.value = 0;
+        progress2.style.accentColor = '#5865f2';
+        percent.innerHTML = '0%';
         for (let i = 0; i < channelIds.length; i++) {
             await deleteMessages(authToken, authorId, guildId, channelIds[i], minId || minDate, maxId || maxDate, content, hasLink, hasFile, includeNsfw, includePinned, logger, stopHndl, onProg);
             stop = stopBtn.disabled = !(startBtn.disabled = false);

--- a/userscript.js
+++ b/userscript.js
@@ -42,12 +42,12 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
     let offset = 0;
     let iterations = -1;
     let ended = false;
-    // let failInRow = 0; this isn't used for anything, gimmick
-    let successInRow = 0; // this is used for delay recovery
+    let failInRow = 0;
+    let successInRow = 0;
 
     const wait = async ms => new Promise(done => setTimeout(done, ms));
     const msToHMS = s => `${s / 3.6e6 | 0}h ${(s % 3.6e6) / 6e4 | 0}m ${(s % 6e4) / 1000 | 0}s`;
-    const escapeHTML = html => html.replace(/[&<"']/g, m => ({ '&': '&amp;', '<': '&lt;', '"': '&quot;', '\'': '&#039;' })[m]);
+    const escapeHTML = html => html.replace(/[&<"']/g, m => ({'&': '&amp;', '<': '&lt;', '"': '&quot;', '\'': '&#039;'})[m]);
     const redact = str => `<span class="priv">${escapeHTML(str)}</span><span class="mask">REDACTED</span>`;
     const queryString = params => params.filter(p => p[1] !== undefined).map(p => p[0] + '=' + encodeURIComponent(p[1])).join('&');
     const ask = async msg => new Promise(resolve => setTimeout(() => resolve(window.confirm(msg)), 10));
@@ -55,12 +55,12 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
     const toSnowflake = (date) => /:/.test(date) ? ((new Date(date).getTime() - 1420070400000) * Math.pow(2, 22)) : date;
 
     const log = {
-        debug() { extLogger ? extLogger('debug', arguments) : console.debug.apply(console, arguments); },
-        info() { extLogger ? extLogger('info', arguments) : console.info.apply(console, arguments); },
-        verb() { extLogger ? extLogger('verb', arguments) : console.log.apply(console, arguments); },
-        warn() { extLogger ? extLogger('warn', arguments) : console.warn.apply(console, arguments); },
-        error() { extLogger ? extLogger('error', arguments) : console.error.apply(console, arguments); },
-        success() { extLogger ? extLogger('success', arguments) : console.info.apply(console, arguments); },
+        debug() {extLogger ? extLogger('debug', arguments) : console.debug.apply(console, arguments);},
+        info() {extLogger ? extLogger('info', arguments) : console.info.apply(console, arguments);},
+        verb() {extLogger ? extLogger('verb', arguments) : console.log.apply(console, arguments);},
+        warn() {extLogger ? extLogger('warn', arguments) : console.warn.apply(console, arguments);},
+        error() {extLogger ? extLogger('error', arguments) : console.error.apply(console, arguments);},
+        success() {extLogger ? extLogger('success', arguments) : console.info.apply(console, arguments);},
     };
 
     async function recurse() {
@@ -91,16 +91,14 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                 ['has', hasFile ? 'file' : undefined],
                 ['content', content || undefined],
                 ['include_nsfw', includeNsfw ? true : undefined],
-            ]), { headers });
+            ]), {headers});
             lastPing = (Date.now() - s);
             avgPing = avgPing > 0 ? (avgPing * 0.9) + (lastPing * 0.1) : lastPing;
         } catch (err) {
             return log.error('Search request threw an error:', err);
         }
 
-        // not indexed yet 
-        // (In testing this seems to literally never trigger,
-        //  why is this here?)
+        // Not indexed yet
         if (resp.status === 202) {
             const w = (await resp.json()).retry_after;
             throttledCount++;
@@ -111,7 +109,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
         }
 
         if (!resp.ok) {
-            // searching messages too fast
+            // Searching messages too fast
             if (resp.status === 429) {
                 const w = (await resp.json()).retry_after;
                 throttledCount++;
@@ -153,7 +151,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
         archivedSkipCount += archivedCount;
         // signal progress UI that undeletable messages were found
         if (skippedMessages.length > 0) {
-            try { if (onProgress) onProgress(delCount, grandTotal || 1, true); } catch (e) { }
+            try {if (onProgress) onProgress(delCount, grandTotal || 1, true);} catch (e) { }
         }
 
         const end = () => {
@@ -215,8 +213,8 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                     lastPing = (Date.now() - s);
                     avgPing = (avgPing * 0.9) + (lastPing * 0.1);
                 } catch (err) {
-                    log.error('Delete request throwed an error:', err); //this is way too long to be read in the console
-                    log.verb('Related object:', redact(JSON.stringify(message))); //this is way too long to be read in the console
+                    log.error('Delete request throwed an error:', err); // Too long to be read in the console
+                    log.verb('Related object:', redact(JSON.stringify(message))); // Too long to be read in the console
                     failCount++;
                     if (i < messagesToDelete.length - 1) {
                         await wait(deleteDelay);
@@ -227,13 +225,13 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                 if (!resp.ok) {
                     // failed
                     let err;
-                    try { err = await resp.json(); } catch { err = null; }
+                    try {err = await resp.json();} catch {err = null;}
 
-                    //  failInRow++;
+                    failInRow++;
                     successInRow = 0;
                     randomizeDelay = false;
 
-                    // Thread Archived or Can't be opened due to missing permissions or rate limits (note: Program can't discern between the two)
+                    // Thread archived or can't be opened due to missing permissions or rate limits (Program can't discern between the two)
                     if ((resp.status === 400 && err?.code === 50083) ||
                         (resp.status === 403 && err?.message && /archiv/i.test(err.message)) ||
                         (resp.status === 404 && err?.message && /archiv/i.test(err.message))) {
@@ -268,7 +266,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                         i--; // retry
                     }
                     //nonspecific error handler
-                    else { 
+                    else {
                         log.error(`Error deleting message, API responded with status ${resp.status}!`, err);
                         log.verb('Related object:', redact(JSON.stringify(message)));
                         failCount++;
@@ -276,11 +274,11 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                 }
                 else {
                     // success
-                    // failInRow = 0;
+                    failInRow = 0;
                     successInRow++;
                     delCount++;
                     // update progress after a successful delete
-                    try { if (onProgress) onProgress(delCount, grandTotal || 1); } catch (e) { }
+                    try {if (onProgress) onProgress(delCount, grandTotal || 1);} catch (e) { }
                     if (randomizeDelay) {
                         deleteDefault = Math.floor(Math.random() * (2000 - 1000 + 1) + 1000);
                         deleteDelay = deleteDefault;
@@ -298,8 +296,6 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                     }
                 }
 
-
-                //skip unnecessary last message delay
                 if (i < messagesToDelete.length - 1) {
                     await wait(deleteDelay);
                 }
@@ -311,7 +307,6 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                 log.verb(`Found ${skippedMessages.length} system messages! Increasing offset to ${offset}.`);
             }
 
-            // skip unnecessary search query
             if (isRunComplete()) {
                 return end();
             }
@@ -331,7 +326,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
 
             return await recurse();
         } else {
-            // nothing on this page could be deleted (either system or archived)
+            // Nothing on this page could be deleted (either system or archived)
             if (skippedMessages.length > 0) {
                 const archivedCount = skippedMessages.filter(msg => ArchivedThreads.has(msg.channel_id)).length;
                 const systemCount = skippedMessages.length - archivedCount;
@@ -364,7 +359,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
     log.success(`\nStarted at ${start.toLocaleString()}`);
     log.debug(`authorId="${redact(authorId)}" guildId="${redact(guildId)}" channelId="${redact(channelId)}" minId="${redact(minId)}" maxId="${redact(maxId)}" hasLink=${!!hasLink} hasFile=${!!hasFile}`);
     ended = false;
-    try { if (onProgress) onProgress(0, 1); } catch (e) { }
+    try {if (onProgress) onProgress(0, 1);} catch (e) { }
     return await recurse();
 }
 
@@ -536,7 +531,7 @@ function initUI() {
     const observer = new MutationObserver(function (_mutationsList, _observer) {
         if (!document.body.contains(btn)) mountBtn(); // re-mount the button to the toolbar
     });
-    observer.observe(document.body, { attributes: false, childList: true, subtree: true });
+    observer.observe(document.body, {attributes: false, childList: true, subtree: true});
 
     mountBtn();
 
@@ -692,7 +687,7 @@ function initUI() {
     };
 
     const logger = (type = '', args) => {
-        const style = { '': '', info: 'color:#00b0f4;', verb: 'color:#72767d;', warn: 'color:#faa61a;', error: 'color:#f04747;', success: 'color:#43b581;' }[type];
+        const style = {'': '', info: 'color:#00b0f4;', verb: 'color:#72767d;', warn: 'color:#faa61a;', error: 'color:#f04747;', success: 'color:#43b581;'}[type];
         logArea.insertAdjacentHTML('beforeend', `<div style="${style}">${Array.from(args).map(o => typeof o === 'object' ? JSON.stringify(o, o instanceof Error && Object.getOwnPropertyNames(o)) : o).join('\t')}</div>`);
         if (autoScroll.checked) logArea.querySelector('div:last-child').scrollIntoView(false);
     };

--- a/userscript.js
+++ b/userscript.js
@@ -26,18 +26,14 @@
  */
 async function deleteMessages(authToken, authorId, guildId, channelId, minId, maxId, content, hasLink, hasFile, includeNsfw, includePinned, extLogger, stopHndl, onProgress) {
     const start = new Date();
-    // keep track of channels (threads) that have been archived so we stop
-    // attempting further deletes against them; the search API may still
-    // return hits for messages in an archived thread, but every delete will
-    // fail and we risk infinite retry loops or excessive rate-limiting.
     const ArchivedThreads = new Set();
     let deleteDefault = Math.floor(Math.random() * (2000 - 1000 + 1) + 1000);
     let deleteDelay = deleteDefault;
     let randomizeDelay = true;
     let searchDelay = Math.floor(Math.random() * (2000 - 1000 + 1) + 1000);
     let delCount = 0;
-    let skipCount = 0;            // messages we could not delete (system/archive)
-    let archivedSkipCount = 0;    // subset of skipCount belonging to archived threads
+    let skipCount = 0;
+    let archivedSkipCount = 0;
     let failCount = 0;
     let avgPing;
     let lastPing;
@@ -47,7 +43,6 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
     let offset = 0;
     let iterations = -1;
     let ended = false;
-
     let failInRow = 0;
     let successInRow = 0;
 
@@ -137,11 +132,11 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
         const total = data.total_results;
         if (!grandTotal) grandTotal = total;
         const discoveredMessages = data.messages.map(convo => convo.find(message => message.hit === true));
-        // Filter out system messages and optionally pinned ones
+        // filter out system messages and optionally pinned ones
         let messagesToDelete = discoveredMessages.filter(msg => {
             return msg.type === 0 || msg.type === 6 || (msg.pinned && includePinned);
         });
-        // remove any messages belonging to threads we've already marked archived
+        // skip message if in archived thread
         messagesToDelete = messagesToDelete.filter(msg => {
             if (ArchivedThreads.has(msg.channel_id)) {
                 log.verb(`Skipping message in archived thread ${msg.channel_id}`);
@@ -171,9 +166,6 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
             // archivedSkipCount retained for diagnostics, but not shown to user
             log.debug(`Deleted ${delCount} messages, ${failCount} failed, ${computedSkip} skipped.\n`);
             // update UI to show final deleted count vs deletable messages
-            // do not update UI here; the last onProgress from the loop already
-            // reflected the most recent state. calling onProgress at end caused
-            // spurious resets (blue/full) when the run ended incomplete.
             ended = true;
         }
 
@@ -185,7 +177,6 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
             `offset: ${offset}`);
         printDelayStats();
         log.verb(`Estimated time remaining: ${etr}`)
-
 
         if (messagesToDelete.length > 0) {
 
@@ -200,7 +191,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
 
             for (let i = 0; i < messagesToDelete.length; i++) {
                 const message = messagesToDelete[i];
-                // if we've already marked this thread as archived, skip
+                // if already marked, skip
                 if (ArchivedThreads.has(message.channel_id)) {
                     log.verb(`Skipping message in archived thread ${message.channel_id}`);
                     continue;
@@ -212,9 +203,6 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                 //log.debug(`${((delCount + 1) / grandTotal * 100).toFixed(2)}% (${delCount + 1}/${grandTotal})` + `Delete ID:${redact(message.id)} <b>${redact(message.author.username + '#' + message.author.discriminator)} <small>(${redact(new Date(message.timestamp).toLocaleString())})</small>:</b> <i>${redact(message.content).replace(/\n/g, '↵')}</i>`, message.attachments.length ? redact(JSON.stringify(message.attachments)) : '');
                 const processed = delCount + skipCount;
                 log.debug(`${((processed + 1) / grandTotal * 100).toFixed(2)}% (${processed + 1}/${grandTotal})` + ` | <b>DEL</b> <small>(${redact(new Date(message.timestamp).toLocaleDateString() + " - " + new Date(message.timestamp).toLocaleTimeString())})</small>: ${redact(message.content).replace(/\n/g, '↵')}`, message.attachments.length ? redact(JSON.stringify(message.attachments)) : '');
-
-
-                // progress reflects actual deleted messages (and adjusts when archived threads are detected)
 
                 let resp;
                 try {
@@ -241,15 +229,12 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                     successInRow = 0;
                     randomizeDelay = false;
 
-                    // thread archived – API can return a few different codes or
-                    // messages depending on context.
+                    // Thread Archived or Can't be opened due to missing permissions or rate limits (note: Program can't discern between the two)
                     if ((resp.status === 400 && err?.code === 50083) ||
                         (resp.status === 403 && err?.message && /archiv/i.test(err.message)) ||
                         (resp.status === 404 && err?.message && /archiv/i.test(err.message))) {
                         log.warn(`Archived thread detected (status ${resp.status}${err?.code ? ', code ' + err.code : ''}), marking channel ${message.channel_id} as archived`);
                         ArchivedThreads.add(message.channel_id);
-                        // accounting/offset for this message is handled in the page-level
-                        // skippedMessages block to avoid double counting.
                         continue;
                     }
 
@@ -278,7 +263,8 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                         await wait(deleteDelay);
                         i--; // retry
                     }
-                    else {
+                    //nonspecific error handler
+                    else { 
                         log.error(`Error deleting message, API responded with status ${resp.status}!`, err);
                         log.verb('Related object:', redact(JSON.stringify(message)));
                         failCount++;
@@ -309,7 +295,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                 }
 
 
-                // avoid an unnecessary delay after processing the last message
+                //skip unnecessary last message delay
                 if (i < messagesToDelete.length - 1) {
                     await wait(deleteDelay);
                 }
@@ -321,6 +307,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                 log.verb(`Found ${skippedMessages.length} system messages! Increasing offset to ${offset}.`);
             }
 
+            // skip unnecessary search query
             // All results are already accounted for (deleted/failed/skipped),
             // no need to issue another search request.
             if ((delCount + failCount + skipCount) >= grandTotal) {
@@ -328,7 +315,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
             }
 
             log.verb(`Searching next messages in ${searchDelay}ms...`, (offset ? `(offset: ${offset})` : ''));
-            // rs
+
             deleteDefault = Math.floor(Math.random() * (2000 - 1000 + 1) + 1000);
             deleteDelay = deleteDefault;
             searchDelay = Math.floor(Math.random() * (2000 - 1000 + 1) + 1000);
@@ -346,7 +333,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
             if (skippedMessages.length > 0) {
                 const archivedCount = skippedMessages.filter(msg => ArchivedThreads.has(msg.channel_id)).length;
                 const systemCount = skippedMessages.length - archivedCount;
-                log.verb(`No deletable messages on this page (${systemCount} system, ${archivedCount} archived). Advancing offset by ${skippedMessages.length}.`);
+                log.verb(`No deletables on this page (${systemCount} system, ${archivedCount} archived). Advancing offset by ${skippedMessages.length}.`);
                 offset += skippedMessages.length;
                 if ((delCount + failCount + skipCount) >= grandTotal) {
                     return end();
@@ -375,7 +362,6 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
     log.success(`\nStarted at ${start.toLocaleString()}`);
     log.debug(`authorId="${redact(authorId)}" guildId="${redact(guildId)}" channelId="${redact(channelId)}" minId="${redact(minId)}" maxId="${redact(maxId)}" hasLink=${!!hasLink} hasFile=${!!hasFile}`);
     ended = false;
-    // initialize progress at 0 so percent shows and color is blue immediately
     try { if (onProgress) onProgress(0, 1); } catch (e) { }
     return await recurse();
 }

--- a/userscript.js
+++ b/userscript.js
@@ -32,7 +32,6 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
     let randomizeDelay = true;
     let searchDelay = Math.floor(Math.random() * (2000 - 1000 + 1) + 1000);
     let delCount = 0;
-    let skipCount = 0;
     let archivedSkipCount = 0;
     let failCount = 0;
     let avgPing;
@@ -43,8 +42,8 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
     let offset = 0;
     let iterations = -1;
     let ended = false;
-    let failInRow = 0;
-    let successInRow = 0;
+    // let failInRow = 0; this isn't used for anything, gimmick
+    let successInRow = 0; // this is used for delay recovery
 
     const wait = async ms => new Promise(done => setTimeout(done, ms));
     const msToHMS = s => `${s / 3.6e6 | 0}h ${(s % 3.6e6) / 6e4 | 0}m ${(s % 6e4) / 1000 | 0}s`;
@@ -99,7 +98,9 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
             return log.error('Search request threw an error:', err);
         }
 
-        // not indexed yet
+        // not indexed yet 
+        // (In testing this seems to literally never trigger,
+        //  why is this here?)
         if (resp.status === 202) {
             const w = (await resp.json()).retry_after;
             throttledCount++;
@@ -145,8 +146,8 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
             return true;
         });
         const skippedMessages = discoveredMessages.filter(msg => !messagesToDelete.find(m => m.id === msg.id));
-        // update global counters
-        skipCount += skippedMessages.length;
+        // count skipped messages as not deleted
+        failCount += skippedMessages.length;
         const archivedCount = skippedMessages.filter(msg => ArchivedThreads.has(msg.channel_id)).length;
         const systemCount = skippedMessages.length - archivedCount;
         archivedSkipCount += archivedCount;
@@ -162,14 +163,11 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
             // unnecessary
             // printDelayStats();
             log.verb(`Rate Limited: ${throttledCount} times. Total time throttled: ${msToHMS(throttledTotalTime)}.`);
-            const computedSkip = grandTotal - delCount - failCount;
-            // archivedSkipCount retained for diagnostics, but not shown to user
-            log.debug(`Deleted ${delCount} messages, ${failCount} failed, ${computedSkip} skipped.\n`);
-            // update UI to show final deleted count vs deletable messages
+            log.debug(`Deleted ${delCount} messages, ${failCount} failed.\n`);
             ended = true;
         }
 
-        const isRunComplete = () => (delCount + failCount + skipCount) >= grandTotal;
+        const isRunComplete = () => (delCount + failCount) >= grandTotal;
 
         const deletableMessages = grandTotal - archivedSkipCount;
         const etr = msToHMS((searchDelay * Math.round(deletableMessages / 25)) + ((deleteDelay + avgPing) * deletableMessages));
@@ -203,7 +201,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                 // Too big to read, too much information to be useful to end user
                 // if you care about individual IDs being deleted or your username, there ya go:
                 //log.debug(`${((delCount + 1) / grandTotal * 100).toFixed(2)}% (${delCount + 1}/${grandTotal})` + `Delete ID:${redact(message.id)} <b>${redact(message.author.username + '#' + message.author.discriminator)} <small>(${redact(new Date(message.timestamp).toLocaleString())})</small>:</b> <i>${redact(message.content).replace(/\n/g, '↵')}</i>`, message.attachments.length ? redact(JSON.stringify(message.attachments)) : '');
-                const processed = delCount + skipCount;
+                const processed = delCount + failCount;
                 log.debug(`${((processed + 1) / grandTotal * 100).toFixed(2)}% (${processed + 1}/${grandTotal})` + ` | <b>DEL</b> <small>(${redact(new Date(message.timestamp).toLocaleDateString() + " - " + new Date(message.timestamp).toLocaleTimeString())})</small>: ${redact(message.content).replace(/\n/g, '↵')}`, message.attachments.length ? redact(JSON.stringify(message.attachments)) : '');
 
                 let resp;
@@ -217,9 +215,13 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                     lastPing = (Date.now() - s);
                     avgPing = (avgPing * 0.9) + (lastPing * 0.1);
                 } catch (err) {
-                    log.error('Delete request throwed an error:', err);
-                    log.verb('Related object:', redact(JSON.stringify(message)));
+                    log.error('Delete request throwed an error:', err); //this is way too long to be read in the console
+                    log.verb('Related object:', redact(JSON.stringify(message))); //this is way too long to be read in the console
                     failCount++;
+                    if (i < messagesToDelete.length - 1) {
+                        await wait(deleteDelay);
+                    }
+                    continue;
                 }
 
                 if (!resp.ok) {
@@ -227,7 +229,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                     let err;
                     try { err = await resp.json(); } catch { err = null; }
 
-                    failInRow++;
+                    //  failInRow++;
                     successInRow = 0;
                     randomizeDelay = false;
 
@@ -274,7 +276,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                 }
                 else {
                     // success
-                    failInRow = 0;
+                    // failInRow = 0;
                     successInRow++;
                     delCount++;
                     // update progress after a successful delete

--- a/userscript.js
+++ b/userscript.js
@@ -169,6 +169,8 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
             ended = true;
         }
 
+        const isRunComplete = () => (delCount + failCount + skipCount) >= grandTotal;
+
         const deletableMessages = grandTotal - archivedSkipCount;
         const etr = msToHMS((searchDelay * Math.round(deletableMessages / 25)) + ((deleteDelay + avgPing) * deletableMessages));
         // systemCount already computed above when updating counters
@@ -308,9 +310,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
             }
 
             // skip unnecessary search query
-            // All results are already accounted for (deleted/failed/skipped),
-            // no need to issue another search request.
-            if ((delCount + failCount + skipCount) >= grandTotal) {
+            if (isRunComplete()) {
                 return end();
             }
 
@@ -335,7 +335,7 @@ async function deleteMessages(authToken, authorId, guildId, channelId, minId, ma
                 const systemCount = skippedMessages.length - archivedCount;
                 log.verb(`No deletables on this page (${systemCount} system, ${archivedCount} archived). Advancing offset by ${skippedMessages.length}.`);
                 offset += skippedMessages.length;
-                if ((delCount + failCount + skipCount) >= grandTotal) {
+                if (isRunComplete()) {
                     return end();
                 }
                 if (offset >= total) {
@@ -543,6 +543,28 @@ function initUI() {
     const startBtn = $('button#start');
     const stopBtn = $('button#stop');
     const autoScroll = $('#autoScroll');
+
+    function resetProgressUI(progress, progress2, percent) {
+        progress.style.display = 'none';
+        progress2.style.display = 'none';
+        progress.removeAttribute('max');
+        progress2.removeAttribute('max');
+        progress.value = 0;
+        progress2.value = 0;
+        progress.style.accentColor = '';
+        progress2.style.accentColor = '';
+        percent.textContent = '';
+    }
+
+    function initializeProgressUI(progress, progress2, percent) {
+        progress.setAttribute('max', 1);
+        progress.value = 0;
+        progress.style.accentColor = '#5865f2';
+        progress2.setAttribute('max', 1);
+        progress2.value = 0;
+        progress2.style.accentColor = '#5865f2';
+        percent.innerHTML = '0%';
+    }
 
     startBtn.onclick = async e => {
         const authToken = $('input#authToken').value.trim();

--- a/userscript.js
+++ b/userscript.js
@@ -2,7 +2,7 @@
 // @name          Discord Mass Deleter
 // @description   Extends the discord interface so you can mass delete messages from discord. Improved all aspects such as timing, backoffs, bugs, etc. Original created by victornpb.
 // @namespace     https://github.com/gen3vra/deletediscordmessages
-// @version       1.3.0
+// @version       1.4
 // @match         https://discord.com/*
 // @grant         none
 // @license       MIT
@@ -372,7 +372,7 @@ let popover;
 let btn;
 let stop;
 let logArea;
-let version = "1.2.1";
+let version = "1.4";
 
 function initUI() {
 
@@ -543,28 +543,6 @@ function initUI() {
     const startBtn = $('button#start');
     const stopBtn = $('button#stop');
     const autoScroll = $('#autoScroll');
-
-    function resetProgressUI(progress, progress2, percent) {
-        progress.style.display = 'none';
-        progress2.style.display = 'none';
-        progress.removeAttribute('max');
-        progress2.removeAttribute('max');
-        progress.value = 0;
-        progress2.value = 0;
-        progress.style.accentColor = '';
-        progress2.style.accentColor = '';
-        percent.textContent = '';
-    }
-
-    function initializeProgressUI(progress, progress2, percent) {
-        progress.setAttribute('max', 1);
-        progress.value = 0;
-        progress.style.accentColor = '#5865f2';
-        progress2.setAttribute('max', 1);
-        progress2.value = 0;
-        progress2.style.accentColor = '#5865f2';
-        percent.innerHTML = '0%';
-    }
 
     startBtn.onclick = async e => {
         const authToken = $('input#authToken').value.trim();


### PR DESCRIPTION
only scuff remaining is it can't tell the difference between a locked thread and one it can't open because it's being rate limited (discord requires threads to reopen for the deletion) but It works fine otherwise.

### summary of all changes:

Bumped version to 1.4.

- Changed deletion counting to increment only on successful deletes.
- Archived threads are now skipped instead of causing retry pileups.
- Adjusted skip/progress/offset behavior around undeletable messages.
- Fixed delete fetch() errors leaving resp undefined and stalling on resp.ok.

### cosmetic:

- Made Clear log also reset the progress bars.
- Added some coloring to the progress bars: green with 100% complete, blue in progress, red if not all messages could be deleted.


### optimizations:

- Commented out per page delay stats.
- suppressed (sometimes repeated) redundant search queries and delays, some of which occurring after the last message had already been processed 

### Formatting/Refactoring

- turned the run-completion check into isRunComplete().
- Merged skipped/failures into one variable
- Cleaned up the comments somewhat
- removed some dead space